### PR TITLE
CNV-24655: hide empty statuses

### DIFF
--- a/src/policies/list/components/EnactmentStateColumn.tsx
+++ b/src/policies/list/components/EnactmentStateColumn.tsx
@@ -18,27 +18,46 @@ const NNCPStateColumn: React.FC<NNCPStateColumnProps> = ({ enactments }) => {
   const { t } = useNMStateTranslation();
 
   const { available, pending, failing, progressing, aborted } = categorizeEnactments(enactments);
+
+  const states = [
+    {
+      icon: <RedExclamationCircleIcon />,
+      number: failing.length,
+      label: 'Failing',
+    },
+    {
+      icon: <CloseIcon color={dangerColor.value} />,
+      number: aborted.length,
+      label: 'Aborted',
+    },
+    {
+      icon: <CheckIcon color={successColor.value} />,
+      number: available.length,
+      label: 'Available',
+    },
+    {
+      icon: <InProgressIcon />,
+      number: progressing.length,
+      label: 'Progressing',
+    },
+    {
+      icon: <HourglassHalfIcon />,
+      number: pending.length,
+      label: 'Pending',
+    },
+  ];
+
   return (
     <Stack hasGutter>
-      {failing.length > 0 && (
-        <StackItem>
-          <RedExclamationCircleIcon /> {failing.length} {t('Failing')}
-        </StackItem>
-      )}
-      {aborted.length > 0 && (
-        <StackItem>
-          <CloseIcon color={dangerColor.value} /> {aborted.length} {t('Aborted')}
-        </StackItem>
-      )}
-      <StackItem>
-        <CheckIcon color={successColor.value} /> {available.length} {t('Available')}
-      </StackItem>
-      <StackItem>
-        <InProgressIcon /> {progressing.length} {t('Progressing')}
-      </StackItem>
-      <StackItem>
-        <HourglassHalfIcon /> {pending.length} {t('Pending')}
-      </StackItem>
+      {states.map((state) => {
+        if (state.number > 0) {
+          return (
+            <StackItem key={state.label}>
+              {state.icon} {state.number} {t(state.label)}
+            </StackItem>
+          );
+        }
+      })}
     </Stack>
   );
 };


### PR DESCRIPTION
Just hide unnecessary enactments statuses 

**Before**
![Screenshot from 2023-01-23 16-42-06](https://user-images.githubusercontent.com/29160323/214082499-42e98776-1887-45af-98a8-4683ec49d6e3.png)




**After**
![Screenshot from 2023-01-23 16-40-30](https://user-images.githubusercontent.com/29160323/214082221-d3fb375e-516a-44d7-8da8-9b3e1b377d9e.png)
