### PR TITLE
CNV-24654: policy status clickable

### DIFF
--- a/cypress/e2e/NewPolicy.spec.cy.ts
+++ b/cypress/e2e/NewPolicy.spec.cy.ts
@@ -10,7 +10,7 @@ const deletePolicyFromDetailsPage = (policyName: string) => {
 
   cy.contains('button', 'Delete').click();
 
-  cy.contains('h1', 'Node Network Configuration Policy', { timeout: TIMEOUT_VISIT_PAGE });
+  cy.contains('h1', 'NodeNetworkConfigurationPolicy', { timeout: TIMEOUT_VISIT_PAGE });
 };
 
 describe('Create new policy with form', () => {

--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -1,5 +1,6 @@
 {
   "{{matchingNodeText}} matching": "{{matchingNodeText}} matching",
+  "{{modelName}} details": "{{modelName}} details",
   "{{qualifiedNodesCount}} matching Nodes found": "{{qualifiedNodesCount}} matching Nodes found",
   "Aborted": "Aborted",
   "Actions": "Actions",
@@ -57,8 +58,6 @@
   "Network state": "Network state",
   "No matching Nodes found for the labels": "No matching Nodes found for the labels",
   "No node network configuration policies defined yet": "No node network configuration policies defined yet",
-  "Node Network Configuration Policy": "Node Network Configuration Policy",
-  "Node Network Configuration Policy details": "Node Network Configuration Policy details",
   "Node network configuration policy interface": "Node network configuration policy interface",
   "Node network is configured and managed by NM state. Create a node netowrk configuration policy to describe the requested network configuration on your nodes in the cluster. The node network configuration enactment reports the netwrok policies enacted upon each node.": "Node network is configured and managed by NM state. Create a node netowrk configuration policy to describe the requested network configuration on your nodes in the cluster. The node network configuration enactment reports the netwrok policies enacted upon each node.",
   "Node network state": "Node network state",

--- a/src/console-models/NodeNetworkConfigurationPolicyModel.ts
+++ b/src/console-models/NodeNetworkConfigurationPolicyModel.ts
@@ -3,6 +3,7 @@ import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-t
 import { modelToGroupVersionKind, modelToRef } from './modelUtils';
 
 const NodeNetworkConfigurationPolicyModel: K8sModel = {
+  // t('NodeNetworkConfigurationPolicy')
   label: 'NodeNetworkConfigurationPolicy',
   labelPlural: 'NodeNetworkConfigurationPolicies',
   apiVersion: 'v1',

--- a/src/policies/constants.ts
+++ b/src/policies/constants.ts
@@ -1,0 +1,12 @@
+export enum EnactmentStatuses {
+  // t('Failing')
+  Failing = 'Failing',
+  // t('Aborted')
+  Aborted = 'Aborted',
+  // t('Available')
+  Available = 'Available',
+  // t('Progressing')
+  Progressing = 'Progressing',
+  // t('Pending')
+  Pending = 'Pending',
+}

--- a/src/policies/details/PolicyPageTitle.tsx
+++ b/src/policies/details/PolicyPageTitle.tsx
@@ -27,10 +27,12 @@ const PolicyPageTitle: React.FC<PolicyPageTitleProps> = ({ policy, name }) => {
         <Breadcrumb className="pf-c-breadcrumb co-breadcrumb">
           <BreadcrumbItem>
             <Link to={getResourceUrl({ model: NodeNetworkConfigurationPolicyModel })}>
-              {t('Node Network Configuration Policy')}
+              {t(NodeNetworkConfigurationPolicyModel.label)}
             </Link>
           </BreadcrumbItem>
-          <BreadcrumbItem>{t('Node Network Configuration Policy details')}</BreadcrumbItem>
+          <BreadcrumbItem>
+            {t('{{modelName}} details', { modelName: NodeNetworkConfigurationPolicyModel.label })}
+          </BreadcrumbItem>
         </Breadcrumb>
       </div>
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">

--- a/src/policies/list/PoliciesList.tsx
+++ b/src/policies/list/PoliciesList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   NodeNetworkConfigurationEnactmentModelGroupVersionKind,
@@ -21,6 +21,8 @@ import {
 import { V1beta1NodeNetworkConfigurationEnactment, V1NodeNetworkConfigurationPolicy } from '@types';
 import { getResourceUrl } from '@utils/helpers';
 
+import { EnactmentStatuses } from '../constants';
+
 import PolicyEnactmentsDrawer from './components/PolicyEnactmentsDrawer/PolicyEnactmentsDrawer';
 import PolicyListEmptyState from './components/PolicyListEmptyState/PolicyListEmptyState';
 import PolicyRow from './components/PolicyRow';
@@ -31,6 +33,7 @@ const PoliciesList: React.FC = () => {
   const { t } = useNMStateTranslation();
   const history = useHistory();
   const [selectedPolicy, setSelectedPolicy] = useState<V1NodeNetworkConfigurationPolicy>();
+  const [selectedState, setSelectedState] = useState<EnactmentStatuses>();
 
   const [policies, policiesLoaded, policiesLoadError] = useK8sWatchResource<
     V1NodeNetworkConfigurationPolicy[]
@@ -71,9 +74,17 @@ const PoliciesList: React.FC = () => {
       )
     : [];
 
+  const onSelectPolicy = useCallback(
+    (policy: V1NodeNetworkConfigurationPolicy, state: EnactmentStatuses) => {
+      setSelectedPolicy(policy);
+      setSelectedState(state);
+    },
+    [],
+  );
+
   return (
     <>
-      <ListPageHeader title={t('Node Network Configuration Policy')}>
+      <ListPageHeader title={t(NodeNetworkConfigurationPolicyModel.label)}>
         <ListPageCreateDropdown
           items={createItems}
           onClick={onCreate}
@@ -109,13 +120,17 @@ const PoliciesList: React.FC = () => {
           columns={activeColumns}
           loadError={policiesLoadError && enactmentsError}
           Row={PolicyRow}
-          rowData={{ selectPolicy: setSelectedPolicy, enactments }}
+          rowData={{ selectPolicy: onSelectPolicy, enactments }}
           NoDataEmptyMsg={() => <PolicyListEmptyState />}
         />
 
         <PolicyEnactmentsDrawer
           selectedPolicy={selectedPolicy}
-          onClose={() => setSelectedPolicy(undefined)}
+          selectedState={selectedState}
+          onClose={() => {
+            setSelectedPolicy(undefined);
+            setSelectedState(undefined);
+          }}
           enactments={selectedPolicyEnactments}
         />
       </ListPageBody>

--- a/src/policies/list/components/EnactmentStateColumn.tsx
+++ b/src/policies/list/components/EnactmentStateColumn.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { EnactmentStatuses } from 'src/policies/constants';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
 import { CheckIcon, CloseIcon, HourglassHalfIcon, InProgressIcon } from '@patternfly/react-icons';
 import { global_danger_color_200 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_200';
 import { global_success_color_200 as successColor } from '@patternfly/react-tokens/dist/js/global_success_color_200';
@@ -12,9 +13,10 @@ import { categorizeEnactments } from './utils';
 
 type NNCPStateColumnProps = {
   enactments: V1beta1NodeNetworkConfigurationEnactment[];
+  onStateClick: (state: EnactmentStatuses) => void;
 };
 
-const NNCPStateColumn: React.FC<NNCPStateColumnProps> = ({ enactments }) => {
+const NNCPStateColumn: React.FC<NNCPStateColumnProps> = ({ enactments, onStateClick }) => {
   const { t } = useNMStateTranslation();
 
   const { available, pending, failing, progressing, aborted } = categorizeEnactments(enactments);
@@ -23,27 +25,27 @@ const NNCPStateColumn: React.FC<NNCPStateColumnProps> = ({ enactments }) => {
     {
       icon: <RedExclamationCircleIcon />,
       number: failing.length,
-      label: 'Failing',
+      label: EnactmentStatuses.Failing,
     },
     {
       icon: <CloseIcon color={dangerColor.value} />,
       number: aborted.length,
-      label: 'Aborted',
+      label: EnactmentStatuses.Aborted,
     },
     {
       icon: <CheckIcon color={successColor.value} />,
       number: available.length,
-      label: 'Available',
+      label: EnactmentStatuses.Available,
     },
     {
       icon: <InProgressIcon />,
       number: progressing.length,
-      label: 'Progressing',
+      label: EnactmentStatuses.Progressing,
     },
     {
       icon: <HourglassHalfIcon />,
       number: pending.length,
-      label: 'Pending',
+      label: EnactmentStatuses.Pending,
     },
   ];
 
@@ -53,7 +55,13 @@ const NNCPStateColumn: React.FC<NNCPStateColumnProps> = ({ enactments }) => {
         if (state.number > 0) {
           return (
             <StackItem key={state.label}>
-              {state.icon} {state.number} {t(state.label)}
+              <Button
+                variant={ButtonVariant.link}
+                isInline
+                onClick={() => onStateClick(state.label)}
+              >
+                {state.icon} {state.number} {t(state.label)}
+              </Button>
             </StackItem>
           );
         }

--- a/src/policies/list/components/PolicyEnactmentsDrawer/PolicyEnactmentsDrawer.tsx
+++ b/src/policies/list/components/PolicyEnactmentsDrawer/PolicyEnactmentsDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { EnactmentStatuses } from 'src/policies/constants';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
@@ -21,12 +22,14 @@ import './policy-enactments-drawer.scss';
 
 type PolicyEnactmentsDrawerProps = {
   selectedPolicy?: V1NodeNetworkConfigurationPolicy;
+  selectedState?: EnactmentStatuses;
   onClose: () => void;
   enactments: V1beta1NodeNetworkConfigurationEnactment[];
 };
 
 const PolicyEnactmentsDrawer: React.FC<PolicyEnactmentsDrawerProps> = ({
   selectedPolicy,
+  selectedState,
   onClose,
   enactments,
 }) => {
@@ -42,19 +45,31 @@ const PolicyEnactmentsDrawer: React.FC<PolicyEnactmentsDrawerProps> = ({
 
   const tabsData = useMemo(
     () => [
-      { title: t('Failing'), icon: <RedExclamationCircleIcon />, enactments: failingEnactments },
       {
-        title: t('Aborted'),
+        title: EnactmentStatuses.Failing,
+        icon: <RedExclamationCircleIcon />,
+        enactments: failingEnactments,
+      },
+      {
+        title: EnactmentStatuses.Aborted,
         icon: <CloseIcon color={dangerColor.value} />,
         enactments: abortedEnactments,
       },
       {
-        title: t('Available'),
+        title: EnactmentStatuses.Available,
         icon: <CheckIcon color={successColor.value} />,
         enactments: availableEnactments,
       },
-      { title: t('Progressing'), icon: <InProgressIcon />, enactments: progressingEnactments },
-      { title: t('Pending'), icon: <HourglassHalfIcon />, enactments: pendingEnactments },
+      {
+        title: EnactmentStatuses.Progressing,
+        icon: <InProgressIcon />,
+        enactments: progressingEnactments,
+      },
+      {
+        title: EnactmentStatuses.Pending,
+        icon: <HourglassHalfIcon />,
+        enactments: pendingEnactments,
+      },
     ],
     [enactments],
   );
@@ -62,8 +77,8 @@ const PolicyEnactmentsDrawer: React.FC<PolicyEnactmentsDrawerProps> = ({
   const [selectedTab, setSelectedTab] = useState<string | number>(0);
 
   useEffect(() => {
-    setSelectedTab(tabsData.findIndex((tab) => tab.enactments.length !== 0));
-  }, [selectedPolicy]);
+    setSelectedTab(tabsData.findIndex((tab) => tab.title === selectedState));
+  }, [selectedPolicy, selectedState]);
 
   return (
     <Modal
@@ -91,7 +106,7 @@ const PolicyEnactmentsDrawer: React.FC<PolicyEnactmentsDrawerProps> = ({
               title={
                 <>
                   <TabTitleIcon>{tabData.icon}</TabTitleIcon>
-                  <TabTitleText> {tabData.title} </TabTitleText>
+                  <TabTitleText> {t(tabData.title)} </TabTitleText>
                 </>
               }
             >

--- a/src/policies/list/components/PolicyRow.tsx
+++ b/src/policies/list/components/PolicyRow.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
 import { NodeNetworkConfigurationPolicyModelGroupVersionKind } from 'src/console-models';
 import PolicyActions from 'src/policies/actions/PolicyActions';
+import { EnactmentStatuses } from 'src/policies/constants';
 import { ENACTMENT_LABEL_POLICY } from 'src/utils/constants';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Button } from '@patternfly/react-core';
 import { V1beta1NodeNetworkConfigurationEnactment, V1NodeNetworkConfigurationPolicy } from '@types';
 
 import EnactmentStateColumn from './EnactmentStateColumn';
@@ -14,7 +14,7 @@ const PolicyRow: FC<
   RowProps<
     V1NodeNetworkConfigurationPolicy,
     {
-      selectPolicy: (policy: V1NodeNetworkConfigurationPolicy) => void;
+      selectPolicy: (policy: V1NodeNetworkConfigurationPolicy, state: EnactmentStatuses) => void;
       enactments: V1beta1NodeNetworkConfigurationEnactment[];
     }
   >
@@ -34,16 +34,15 @@ const PolicyRow: FC<
         />
       </TableData>
       <TableData id="nodes" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
-        {policyEnactments.length === 0 && <>0 {t('nodes')}</>}
-
-        {policyEnactments.length !== 0 && (
-          <Button variant="link" isInline onClick={() => selectPolicy(obj)}>
-            {policyEnactments.length} {t('nodes')}
-          </Button>
-        )}
+        <span>
+          {policyEnactments.length} {t('nodes')}
+        </span>
       </TableData>
       <TableData id="status" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
-        <EnactmentStateColumn enactments={policyEnactments} />
+        <EnactmentStateColumn
+          enactments={policyEnactments}
+          onStateClick={(state) => selectPolicy(obj, state)}
+        />
       </TableData>
       <TableData
         id="actions"


### PR DESCRIPTION
Instead of clicking nodes, to open the drawer you have to click the statuses. 
The drawer will be open on the clicked status tab 

![Screenshot from 2023-01-24 15-57-50](https://user-images.githubusercontent.com/29160323/214328658-9afe89d6-ab47-41cc-8db8-5454a7e96753.png)
![Screenshot from 2023-01-24 15-57-42](https://user-images.githubusercontent.com/29160323/214328660-71577612-bb6c-4aed-adef-367f63dbaaac.png)
