### PR TITLE
Enable MultiArch image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,15 +7,17 @@ jobs:
   deploy:
     name: deploy
     runs-on: ubuntu-latest
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Quay.io
         uses: docker/login-action@v1
@@ -26,7 +28,9 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: quay.io/nmstate/nmstate-console-plugin:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder container
-FROM registry.access.redhat.com/ubi9/nodejs-16 AS build
+FROM registry.access.redhat.com/ubi9/nodejs-18 AS build
 
 # Install yarn
 RUN npm install -g yarn -s &>/dev/null
@@ -10,7 +10,7 @@ WORKDIR /opt/app-root/src/app
 
 # Run install as supper tux
 USER 0
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 # Web server container
 FROM registry.access.redhat.com/ubi9/nginx-120


### PR DESCRIPTION
The nmstate-console-plugin image will be built not only for amd64, but also for arm64, ppc64le and s390x architectures, so it can be deployed on a variaty of platforms.