### PR TITLE
CNV-8424: Add Drawer with interface basic info

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,7 @@ extends:
   - plugin:react/recommended
   - plugin:@typescript-eslint/recommended
   - prettier
-parser: '@typescript-eslint/parser'
+parser: "@typescript-eslint/parser"
 parserOptions:
   ecmaFeatures:
     jsx: true
@@ -15,9 +15,13 @@ parserOptions:
 plugins:
   - prettier
   - react
-  - '@typescript-eslint'
+  - "@typescript-eslint"
   - simple-import-sort
 rules:
+  "@typescript-eslint/no-unused-vars":
+    - error
+  react/prop-types:
+    - off
   prettier/prettier:
     - error
   simple-import-sort/exports:
@@ -25,13 +29,15 @@ rules:
   simple-import-sort/imports:
     - warn
     - groups:
-      - ["^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)"]
-      - ["^react", "^\\w"]
-      - ["^(@|config/)(/*|$)"]
-      - ["^\\u0000"]
-      - ["^\\.\\.(?!/?$)", "^\\.\\./?$"]
-      - ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"]
-      - ["^.+\\.s?css$"]
+        - [
+            "^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)",
+          ]
+        - ["^react", "^\\w"]
+        - ["^(@|config/)(/*|$)"]
+        - ["^\\u0000"]
+        - ["^\\.\\.(?!/?$)", "^\\.\\./?$"]
+        - ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"]
+        - ["^.+\\.s?css$"]
 settings:
   react:
     version: detect

--- a/src/nmstate-types/custom-models/NodeNetworkConfigurationInterface.ts
+++ b/src/nmstate-types/custom-models/NodeNetworkConfigurationInterface.ts
@@ -1,5 +1,6 @@
 import { NodeNetworkConfigurationInterfaceBridge } from './NodeNetworkConfigurationInterfaceBridge';
 import { NodeNetworkConfigurationInterfaceEthernet } from './NodeNetworkConfigurationInterfaceEthernet';
+import { NodeNetworkConfigurationInterfaceEthtool } from './NodeNetworkConfigurationInterfaceEthtool';
 import { NodeNetworkConfigurationInterfaceIPV4 } from './NodeNetworkConfigurationInterfaceIPV4';
 import { NodeNetworkConfigurationInterfaceIPV6 } from './NodeNetworkConfigurationInterfaceIPV6';
 import { NodeNetworkConfigurationInterfaceLinkAggregation } from './NodeNetworkConfigurationInterfaceLinkAggregation';
@@ -30,4 +31,6 @@ export interface NodeNetworkConfigurationInterface {
   'link-aggregation'?: NodeNetworkConfigurationInterfaceLinkAggregation;
   bridge?: NodeNetworkConfigurationInterfaceBridge;
   ethernet?: NodeNetworkConfigurationInterfaceEthernet;
+
+  ethtool?: NodeNetworkConfigurationInterfaceEthtool;
 }

--- a/src/nmstate-types/custom-models/NodeNetworkConfigurationInterfaceEthtool.ts
+++ b/src/nmstate-types/custom-models/NodeNetworkConfigurationInterfaceEthtool.ts
@@ -1,0 +1,44 @@
+/** The ethtool section of interface holds the ethtool settings of network cards, including these subsections. */
+export interface NodeNetworkConfigurationInterfaceEthtool {
+  pause?: {
+    rx: boolean;
+    tx: boolean;
+    autoneg: boolean;
+  };
+  feature?: {
+    [key in string]: boolean;
+  };
+  coalesce?: {
+    ['adaptive-rx']?: boolean;
+    ['adaptive-tx']?: boolean;
+    ['pkt-rate-high']?: number;
+    ['pkt-rate-low']?: number;
+    ['rx-frames']?: number;
+    ['rx-frames-high']?: number;
+    ['rx-frames-low']?: number;
+    ['rx-usecs']?: number;
+    ['rx-usecs-high']?: number;
+    ['rx-usecs-irq']?: number;
+    ['rx-usecs-low']?: number;
+    ['sample-interval']?: number;
+    ['stats-block-usecs']?: number;
+    ['tx-frames']?: number;
+    ['tx-frames-high']?: number;
+    ['tx-frames-irq']?: number;
+    ['tx-frames-low']?: number;
+    ['tx-usecs']?: number;
+    ['tx-usecs-high']?: number;
+    ['tx-usecs-irq']?: number;
+    ['tx-usecs-low']?: number;
+  };
+  ring?: {
+    rx?: number;
+    ['rx-max']?: number;
+    ['rx-jumbo']?: number;
+    ['rx-jumbo-max']?: number;
+    ['rx-mini']?: number;
+    ['rx-mini-max']?: number;
+    tx?: number;
+    ['tx-max']?: number;
+  };
+}

--- a/src/views/policies/list/components/PolicyEnactmentsDrawer/PolicyEnactmentsDrawer.tsx
+++ b/src/views/policies/list/components/PolicyEnactmentsDrawer/PolicyEnactmentsDrawer.tsx
@@ -82,7 +82,7 @@ const PolicyEnactmentsDrawer: FC<PolicyEnactmentsDrawerProps> = ({
 
   return (
     <Modal
-      aria-label="Template drawer"
+      aria-label="Policy enactments drawer"
       className="ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right policy-enactments-drawer"
       isOpen={!!selectedPolicy}
       onClose={onClose}

--- a/src/views/states/list/StatesList.tsx
+++ b/src/views/states/list/StatesList.tsx
@@ -18,8 +18,10 @@ import { Table, TableGridBreakpoint, TableHeader } from '@patternfly/react-table
 import { AutoSizer, VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import { V1beta1NodeNetworkState } from '@types';
 
+import InterfaceDrawer from './components/InterfaceDrawer/InterfaceDrawer';
 import StateRow from './components/StateRow';
 import StatusBox from './components/StatusBox';
+import { DrawerContextProvider } from './contexts/DrawerContext';
 import useStateColumns from './hooks/useStateColumns';
 import useStateFilters from './hooks/useStateFilters';
 
@@ -64,7 +66,7 @@ const StatesList: FC = () => {
   };
 
   return (
-    <>
+    <DrawerContextProvider>
       <ListPageHeader title={t(NodeNetworkStateModel.label)}></ListPageHeader>
       <ListPageBody>
         <StatusBox loaded={statesLoaded} error={statesError} data={states}>
@@ -113,7 +115,8 @@ const StatesList: FC = () => {
           </Table>
         </StatusBox>
       </ListPageBody>
-    </>
+      <InterfaceDrawer />
+    </DrawerContextProvider>
   );
 };
 

--- a/src/views/states/list/components/InterfaceDrawer/InterfaceDrawer.tsx
+++ b/src/views/states/list/components/InterfaceDrawer/InterfaceDrawer.tsx
@@ -1,0 +1,69 @@
+import React, { FC, useCallback } from 'react';
+
+import { Modal, Title } from '@patternfly/react-core';
+import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+
+import { useDrawerContext } from '../../contexts/DrawerContext';
+
+import InterfaceDrawerDetailsTab from './InterfaceDrawerDetailsTab';
+import InterfaceDrawerYAMLTab from './InterfaceDrawerYAMLTab';
+
+const InterfaceDrawer: FC = () => {
+  const { t } = useNMStateTranslation();
+  const { selectedInterface, setSelectedInterface } = useDrawerContext();
+
+  const onClose = useCallback(() => {
+    setSelectedInterface(null);
+  }, []);
+
+  const Tabs = [
+    {
+      title: t('Details'),
+      id: 'drawer-details',
+      component: InterfaceDrawerDetailsTab,
+    },
+    {
+      title: t('YAML'),
+      id: 'drawer-yaml',
+      component: InterfaceDrawerYAMLTab,
+    },
+  ];
+
+  const selectedTab = location.hash.replace('#', '') || Tabs?.[0]?.id;
+
+  const SelectedTabComponent =
+    Tabs.find((tab) => tab.id === selectedTab)?.component ?? Tabs?.[0]?.component;
+
+  return (
+    <Modal
+      aria-label="Interface drawer"
+      className="ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right interface-drawer"
+      isOpen={!!selectedInterface}
+      onClose={onClose}
+      disableFocusTrap
+      header={<Title headingLevel="h2">{selectedInterface?.name}</Title>}
+    >
+      <div className="co-m-horizontal-nav pf-u-px-md">
+        <ul className="co-m-horizontal-nav__menu">
+          {Tabs.map((tab) => (
+            <li
+              key={tab.id}
+              className={`co-m-horizontal-nav__menu-item ${
+                selectedTab === tab.id ? 'co-m-horizontal-nav-item--active' : ''
+              }`}
+            >
+              <a data-test-id="horizontal-link-Details" href={`${location.pathname}#${tab.id}`}>
+                {tab.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="pf-u-p-xl">
+        <SelectedTabComponent selectedInterface={selectedInterface} />
+      </div>
+    </Modal>
+  );
+};
+
+export default InterfaceDrawer;

--- a/src/views/states/list/components/InterfaceDrawer/InterfaceDrawerDetailsTab.tsx
+++ b/src/views/states/list/components/InterfaceDrawer/InterfaceDrawerDetailsTab.tsx
@@ -1,0 +1,59 @@
+import React, { FC } from 'react';
+
+import { Checkbox, Flex, FlexItem, List, ListItem, Title } from '@patternfly/react-core';
+import { NodeNetworkConfigurationInterface } from '@types';
+
+type InterfaceDrawerDetailsTabProps = {
+  selectedInterface: NodeNetworkConfigurationInterface;
+};
+
+const InterfaceDrawerDetailsTab: FC<InterfaceDrawerDetailsTabProps> = ({ selectedInterface }) => {
+  const ports = selectedInterface.bridge?.port?.map((port) => port.name);
+
+  return (
+    <div>
+      {selectedInterface.ethtool?.feature && (
+        <div className="pf-u-mb-md">
+          <Title headingLevel="h4">Features</Title>
+          <List isPlain>
+            {Object.keys(selectedInterface.ethtool?.feature)?.map((feature) => (
+              <ListItem key={feature}>
+                <Flex>
+                  <FlexItem>
+                    <Checkbox
+                      isDisabled
+                      id={`checkbox-${feature}`}
+                      value={feature}
+                      isChecked={selectedInterface.ethtool?.feature?.[feature]}
+                    />
+                  </FlexItem>
+
+                  <FlexItem>{feature}</FlexItem>
+                </Flex>
+              </ListItem>
+            ))}
+          </List>
+        </div>
+      )}
+      {selectedInterface.bridge?.port?.length > 0 && (
+        <div className="pf-u-mb-md">
+          <Title headingLevel="h4">Ports</Title>
+          <List isPlain>
+            {ports?.map((port) => (
+              <ListItem key={port}>{port}</ListItem>
+            ))}
+          </List>
+        </div>
+      )}
+
+      {selectedInterface['mac-address'] && (
+        <div className="pf-u-mb-md">
+          <Title headingLevel="h4">Mac Address</Title>
+          <p>{selectedInterface['mac-address']}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InterfaceDrawerDetailsTab;

--- a/src/views/states/list/components/InterfaceDrawer/InterfaceDrawerYAMLTab.tsx
+++ b/src/views/states/list/components/InterfaceDrawer/InterfaceDrawerYAMLTab.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react';
+import { dump } from 'js-yaml';
+
+import { NodeNetworkConfigurationInterface } from '@types';
+
+type InterfaceDrawerYAMLTabProps = {
+  selectedInterface: NodeNetworkConfigurationInterface;
+};
+
+const InterfaceDrawerYAMLTab: FC<InterfaceDrawerYAMLTabProps> = ({ selectedInterface }) => (
+  <pre>{dump(selectedInterface)}</pre>
+);
+
+export default InterfaceDrawerYAMLTab;

--- a/src/views/states/list/components/InterfacesTypeSection.tsx
+++ b/src/views/states/list/components/InterfacesTypeSection.tsx
@@ -1,8 +1,17 @@
-import React, { FC, useState } from 'react';
+import React, { FC, memo, useState } from 'react';
 
-import { ExpandableSectionToggle, List, ListItem, Tooltip } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  ExpandableSectionToggle,
+  List,
+  ListItem,
+  Tooltip,
+} from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
 import { NodeNetworkConfigurationInterface } from '@types';
+
+import { useDrawerContext } from '../contexts/DrawerContext';
 
 import './interfaces-table.scss';
 
@@ -11,63 +20,73 @@ interface InterfacesTypeSectionProps {
   interfaceType: string;
 }
 
-const InterfacesTypeSection: FC<InterfacesTypeSectionProps> = ({ interfaceType, interfaces }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+const InterfacesTypeSection: FC<InterfacesTypeSectionProps> = memo(
+  ({ interfaceType, interfaces }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
 
-  return (
-    <>
-      <Tr className="interfaces-table__interface-type-row">
-        <Td colSpan={6}>
-          <ExpandableSectionToggle
-            isExpanded={isExpanded}
-            onToggle={setIsExpanded}
-            className="expandable-section-interface-type"
-          >
-            {interfaceType}
-          </ExpandableSectionToggle>
-        </Td>
-      </Tr>
+    const { setSelectedInterface } = useDrawerContext();
 
-      {interfaces.map((iface) => {
-        const address = iface.ipv4?.address || iface.ipv6?.address;
+    return (
+      <>
+        <Tr className="interfaces-table__interface-type-row">
+          <Td colSpan={6}>
+            <ExpandableSectionToggle
+              isExpanded={isExpanded}
+              onToggle={setIsExpanded}
+              className="expandable-section-interface-type"
+            >
+              {interfaceType}
+            </ExpandableSectionToggle>
+          </Td>
+        </Tr>
 
-        return (
-          <Tr key={iface.name} isExpanded={isExpanded}>
-            <Td className="pf-m-width-20">{iface.name}</Td>
-            <Td>
-              {address ? (
-                <>
-                  {address?.[0]?.ip}/{address?.[0]?.['prefix-length']}
-                </>
-              ) : (
-                '-'
-              )}
-            </Td>
-            <Td>
-              {iface.bridge?.port?.length ? (
-                <Tooltip
-                  content={
-                    <List isPlain>
-                      {iface?.bridge?.port.map((portItem) => (
-                        <ListItem key={portItem.name}>{portItem.name}</ListItem>
-                      ))}
-                    </List>
-                  }
-                >
-                  <span> {iface?.bridge?.port?.length}</span>
-                </Tooltip>
-              ) : (
-                '-'
-              )}
-            </Td>
-            <Td>{iface?.['mac-address'] || '-'}</Td>
-            <Td>-</Td>
-            <Td>{iface?.mtu || '-'}</Td>
-          </Tr>
-        );
-      })}
-    </>
-  );
-};
+        {interfaces.map((iface) => {
+          const address = iface.ipv4?.address || iface.ipv6?.address;
+
+          return (
+            <Tr key={iface.name} isExpanded={isExpanded}>
+              <Td className="pf-m-width-20">
+                <Button variant={ButtonVariant.link} onClick={() => setSelectedInterface(iface)}>
+                  {iface.name}
+                </Button>
+              </Td>
+              <Td>
+                {address ? (
+                  <>
+                    {address?.[0]?.ip}/{address?.[0]?.['prefix-length']}
+                  </>
+                ) : (
+                  '-'
+                )}
+              </Td>
+              <Td>
+                {iface.bridge?.port?.length ? (
+                  <Tooltip
+                    content={
+                      <List isPlain>
+                        {iface?.bridge?.port.map((portItem) => (
+                          <ListItem key={portItem.name}>{portItem.name}</ListItem>
+                        ))}
+                      </List>
+                    }
+                  >
+                    <span> {iface?.bridge?.port?.length}</span>
+                  </Tooltip>
+                ) : (
+                  '-'
+                )}
+              </Td>
+              <Td>{iface?.['mac-address'] || '-'}</Td>
+              <Td>-</Td>
+              <Td>{iface?.mtu || '-'}</Td>
+            </Tr>
+          );
+        })}
+      </>
+    );
+  },
+);
+
+InterfacesTypeSection.displayName = 'InterfacesTypeSection';
 
 export default InterfacesTypeSection;

--- a/src/views/states/list/contexts/DrawerContext.tsx
+++ b/src/views/states/list/contexts/DrawerContext.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import React, { createContext, FC, ReactElement, ReactNode, useContext, useState } from 'react';
+import { NodeNetworkConfigurationInterface } from 'src/nmstate-types/custom-models/NodeNetworkConfigurationInterface';
+
+type DrawerContextProps = {
+  selectedInterface: NodeNetworkConfigurationInterface;
+  setSelectedInterface: (selectedInterface: NodeNetworkConfigurationInterface) => void;
+};
+
+export const DrawerContext = createContext<DrawerContextProps>({
+  selectedInterface: null,
+  setSelectedInterface: () => {},
+});
+
+export const useDrawerContext = () => useContext(DrawerContext);
+
+export const DrawerContextProvider: FC<{ children: ReactNode | ReactElement }> = ({ children }) => {
+  const [selectedInterface, setSelectedInterface] = useState(null);
+
+  return (
+    <DrawerContext.Provider value={{ selectedInterface, setSelectedInterface }}>
+      {children}
+    </DrawerContext.Provider>
+  );
+};


### PR DESCRIPTION
Drawer on interface click

Drawer has 'Details' and 'YAML' menu

I was not able to use the HorizontalNav as it requires completely changing the URL on click (ex. from `/LISTURL/yaml` to `/LIST_URL/details`) and reloading the page. 

But the user does not change the page. So I copied the classes to have the same design. 
An alternative would be to use the Patternfly Tabs that do not have the same UI. 

![Screenshot from 2023-06-14 10-31-44](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/69e7d2ef-7633-4407-8439-b9b77c97da5e)
![Screenshot from 2023-06-14 10-31-38](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/fe3459d6-98fc-4ccc-afd8-69da3e93a2c2)
![Screenshot from 2023-06-14 10-31-32](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/24e68af2-96c7-4116-bab2-97473ae1a217)
