### PR TITLE
OCPBUGS-15510: Policy name uneditable

### DIFF
--- a/src/utils/components/PolicyForm/PolicyForm.tsx
+++ b/src/utils/components/PolicyForm/PolicyForm.tsx
@@ -96,6 +96,7 @@ const PolicyForm: FC<PolicyFormProps> = ({ policy, setPolicy, createForm = false
           id="policy-name"
           name="policy-name"
           value={policy?.metadata?.name}
+          isDisabled={!createForm}
           onChange={(newName) =>
             setPolicy((draftPolicy) => {
               draftPolicy.metadata.name = newName;


### PR DESCRIPTION
The policy name is not editable after creation.

Disable input on edit form

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/5dae5f7e-bdf5-4c12-be4d-88cb3e405b0c)
