### PR TITLE
OCPBUGS-15511: disable interface name-type only if already created

### DIFF
--- a/src/utils/components/PolicyForm/PolicyInterface.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterface.tsx
@@ -38,7 +38,7 @@ type HandleSelectChange = SelectProps['onSelect'];
 
 type PolicyInterfaceProps = {
   id: number;
-  editForm?: boolean;
+  createdInterface?: boolean;
   policyInterface?: NodeNetworkConfigurationInterface;
   onInterfaceChange?: (updateInterface: onInterfaceChangeType) => void;
 };
@@ -47,7 +47,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
   id,
   policyInterface,
   onInterfaceChange,
-  editForm = true,
+  createdInterface = true,
 }) => {
   const { t } = useNMStateTranslation();
   const [isStateOpen, setStateOpen] = useState(false);
@@ -167,7 +167,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
           name={`policy-interface-name-${id}`}
           value={policyInterface?.name}
           onChange={handleNameChange}
-          isDisabled={editForm}
+          isDisabled={createdInterface}
         />
       </FormGroup>
       <FormGroup
@@ -201,7 +201,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
           onSelect={handleTypechange}
           variant={SelectVariant.single}
           selections={policyInterface?.type}
-          isDisabled={editForm}
+          isDisabled={createdInterface}
         >
           {Object.entries(INTERFACE_TYPE_OPTIONS).map(([key, value]) => (
             <SelectOption key={key} value={key}>
@@ -332,7 +332,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
             label={
               <Text>
                 {t('Enable STP')}{' '}
-                {editForm && (
+                {createdInterface && (
                   <Popover
                     aria-label={'Help'}
                     bodyContent={() => <div>{t('Edit the STP in the YAML file')}</div>}
@@ -345,7 +345,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
             id={`policy-interface-stp-${id}`}
             isChecked={policyInterface?.bridge?.options?.stp?.enabled}
             onChange={onSTPChange}
-            isDisabled={editForm}
+            isDisabled={createdInterface}
           />
         </FormGroup>
       )}

--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -22,6 +22,7 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
   createForm,
 }) => {
   const createdPolicy = useRef(createForm ? undefined : policy);
+
   const [interfaceToDelete, setInterfaceToDelete] = useState<NodeNetworkConfigurationInterface>();
   const { t } = useNMStateTranslation();
 
@@ -72,7 +73,11 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
         >
           <PolicyInterface
             id={index}
-            editForm={!createForm}
+            createdInterface={
+              !!createdPolicy?.current?.spec?.desiredState?.interfaces?.find(
+                (iface) => iface.name === policyInterface.name,
+              )
+            }
             policyInterface={policyInterface}
             onInterfaceChange={(updateInterface: onInterfaceChangeType) =>
               setPolicy((draftPolicy) => {


### PR DESCRIPTION
In the editform do not disable fields for added interfaces. 
Disable just for interfaces already created 

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/3647ca23-3d5c-4f0b-809a-ee8d3b66136d)

![Screenshot from 2023-06-29 12-07-54](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/5148c46f-6d86-4e24-8fa1-fa4e21cd9aee)
