### PR TITLE
OCPBUGS-15466: fix edit modal error

### DIFF
--- a/src/utils/components/PolicyForm/PolicyInterface.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterface.tsx
@@ -134,6 +134,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
       draftInterface['link-aggregation'].mode =
         aggregationMode as NodeNetworkConfigurationInterfaceBondMode;
     });
+    setAggregationOpen(false);
   };
 
   const onPortChange = (value: string) => {
@@ -372,7 +373,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               selections={policyInterface?.['link-aggregation']?.mode}
             >
               {Object.entries(NodeNetworkConfigurationInterfaceBondMode).map(([key, value]) => (
-                <SelectOption key={key} value={key}>
+                <SelectOption key={key} value={value}>
                   {value}
                 </SelectOption>
               ))}

--- a/src/views/policies/components/EditModal.tsx
+++ b/src/views/policies/components/EditModal.tsx
@@ -33,6 +33,7 @@ const EditModal: FC<EditModalProps> = ({ closeModal, isOpen, policy }) => {
 
   const handleSubmit: MouseEventHandler<HTMLButtonElement> = (event) => {
     event.preventDefault();
+    setError(undefined);
     setLoading(true);
 
     return k8sUpdate({
@@ -44,7 +45,6 @@ const EditModal: FC<EditModalProps> = ({ closeModal, isOpen, policy }) => {
       .then(() => closeModal())
       .catch(setError)
       .finally(() => {
-        setError(undefined);
         setLoading(false);
       });
   };

--- a/src/views/policies/list/components/EnactmentStateColumn.tsx
+++ b/src/views/policies/list/components/EnactmentStateColumn.tsx
@@ -47,25 +47,18 @@ const NNCPStateColumn: FC<NNCPStateColumnProps> = ({ enactments, onStateClick })
       number: pending.length,
       label: EnactmentStatuses.Pending,
     },
-  ];
+  ].filter((state) => state.number > 0);
 
   return (
     <Stack hasGutter>
-      {states.map((state) => {
-        if (state.number > 0) {
-          return (
-            <StackItem key={state.label}>
-              <Button
-                variant={ButtonVariant.link}
-                isInline
-                onClick={() => onStateClick(state.label)}
-              >
-                {state.icon} {state.number} {t(state.label)}
-              </Button>
-            </StackItem>
-          );
-        }
-      })}
+      {states.length === 0 && <StackItem>-</StackItem>}
+      {states.map((state) => (
+        <StackItem key={state.label}>
+          <Button variant={ButtonVariant.link} isInline onClick={() => onStateClick(state.label)}>
+            {state.icon} {state.number} {t(state.label)}
+          </Button>
+        </StackItem>
+      ))}
     </Stack>
   );
 };


### PR DESCRIPTION
Cause: Aggregation mode was using uppercase (Object `NodeNetworkConfigurationInterfaceBondMode` keys instead of values )

And I fixed two more things: Show the error message in the edit modal if there is one, close the aggregation mode select when the user selects something from there, and make sure the policy row does not break vertically when there is no enhancement shown (picture below).

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/1caf88df-5d3d-41a2-9b49-01a2e33559c4)
 