### PR TITLE
Add interface type popover with list and details

### DIFF
--- a/src/views/states/list/components/InterfacesPopoverBody.tsx
+++ b/src/views/states/list/components/InterfacesPopoverBody.tsx
@@ -1,0 +1,107 @@
+import React, { FC, useCallback } from 'react';
+
+import {
+  Button,
+  ButtonVariant,
+  Checkbox,
+  Flex,
+  FlexItem,
+  List,
+  ListItem,
+} from '@patternfly/react-core';
+import { LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
+import { NodeNetworkConfigurationInterface } from '@types';
+
+import { useDrawerContext } from '../contexts/DrawerContext';
+
+import './interfaces-popover-body.scss';
+
+type InterfacesPopoverBodyProps = {
+  interfaces: NodeNetworkConfigurationInterface[];
+  hide: () => void;
+};
+
+const Row = ({ children }) => <Flex flexWrap={{ default: 'nowrap' }}>{children}</Flex>;
+const FirstColumn = ({ children }) => <FlexItem flex={{ default: 'flex_1' }}>{children}</FlexItem>;
+const SecondColumn = ({ children }) => <FlexItem flex={{ default: 'flex_3' }}>{children}</FlexItem>;
+
+const InterfacesPopoverBody: FC<InterfacesPopoverBodyProps> = ({ interfaces, hide }) => {
+  const { setSelectedInterface } = useDrawerContext();
+
+  const onInterfaceNameClick = useCallback(
+    (iface: NodeNetworkConfigurationInterface) => {
+      setSelectedInterface(iface);
+      hide();
+    },
+    [hide, setSelectedInterface],
+  );
+
+  return (
+    <List isPlain className="interfaces-popover-body" isBordered>
+      {interfaces.map((iface) => {
+        const address = iface.ipv4?.address || iface.ipv6?.address;
+        const Icon = iface.state.toLowerCase() === 'up' ? LongArrowAltUpIcon : LongArrowAltDownIcon;
+
+        return (
+          <ListItem key={iface.name} className="interfaces-popover-body__list-item">
+            <Row>
+              <FirstColumn>
+                <strong>Name</strong>
+              </FirstColumn>
+              <SecondColumn>
+                <Button
+                  variant={ButtonVariant.link}
+                  onClick={() => onInterfaceNameClick(iface)}
+                  className="interface-button-name"
+                >
+                  {iface.name} <Icon color="black" className="pf-u-mr-sm" />
+                </Button>
+              </SecondColumn>
+            </Row>
+            <Row>
+              <FirstColumn>
+                <strong>IP address</strong>
+              </FirstColumn>
+              <SecondColumn>
+                {address?.[0] ? (
+                  <>
+                    {address?.[0]?.ip}/{address?.[0]?.['prefix-length']}
+                  </>
+                ) : (
+                  '-'
+                )}
+              </SecondColumn>
+            </Row>
+            <Row>
+              <FirstColumn>
+                <strong>Ports</strong>
+              </FirstColumn>
+              <SecondColumn>{iface.bridge?.port?.length || '-'}</SecondColumn>
+            </Row>
+            <Row>
+              <FirstColumn>
+                <strong>LLDP</strong>
+              </FirstColumn>
+              <SecondColumn>
+                <Checkbox
+                  id={`lldp-enabled-${iface.name}`}
+                  isDisabled
+                  isChecked={iface.lldp?.enabled}
+                />
+              </SecondColumn>
+            </Row>
+
+            <Row>
+              <FirstColumn>
+                <strong>MTU</strong>
+              </FirstColumn>
+              <SecondColumn>{iface?.mtu || '-'}</SecondColumn>
+            </Row>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+};
+
+export default InterfacesPopoverBody;

--- a/src/views/states/list/components/StateRow.tsx
+++ b/src/views/states/list/components/StateRow.tsx
@@ -2,11 +2,12 @@ import React, { FC, useState } from 'react';
 import { NodeNetworkStateModelGroupVersionKind } from 'src/console-models';
 
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { List, ListItem, Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, List, ListItem, Popover, Title } from '@patternfly/react-core';
 import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
 import { InterfaceType, V1beta1NodeNetworkState } from '@types';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
 
+import InterfacesPopoverBody from './InterfacesPopoverBody';
 import InterfacesTable from './InterfacesTable';
 
 const StateRow: FC<RowProps<V1beta1NodeNetworkState, { rowIndex: number }>> = ({
@@ -52,7 +53,24 @@ const StateRow: FC<RowProps<V1beta1NodeNetworkState, { rowIndex: number }>> = ({
           <List isPlain>
             {Object.keys(interfacesByType)?.map((interfaceType) => (
               <ListItem key={interfaceType}>
-                {interfaceType} ({interfacesByType[interfaceType].length})
+                <Popover
+                  headerContent={
+                    <>
+                      {interfaceType} ({interfacesByType[interfaceType].length})
+                    </>
+                  }
+                  bodyContent={(hide) => (
+                    <InterfacesPopoverBody
+                      interfaces={interfacesByType[interfaceType]}
+                      hide={hide}
+                    />
+                  )}
+                  aria-label="Interfaces list"
+                >
+                  <Button variant={ButtonVariant.link}>
+                    {interfaceType} ({interfacesByType[interfaceType].length})
+                  </Button>
+                </Popover>
               </ListItem>
             ))}
           </List>

--- a/src/views/states/list/components/interfaces-popover-body.scss
+++ b/src/views/states/list/components/interfaces-popover-body.scss
@@ -1,0 +1,15 @@
+.interfaces-popover-body {
+  max-height: 700px;
+  overflow-y: scroll;
+
+  &__list-item {
+    & > div > div {
+      padding: var(--pf-global--spacer--xs);
+    }
+
+    .interface-button-name {
+      padding: 0;
+      white-space: break-spaces;
+    } 
+  }
+}


### PR DESCRIPTION
Add popover at interface type click to have interface details without unwrapping the list element

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/b9c551fb-2c97-4fcd-bfbb-15430507b76f)
