### PR TITLE
fix: dhcp flags default true

### DIFF
--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -99,6 +99,8 @@
   "Progressing": "Progressing",
   "Remove": "Remove",
   "Remove all dependencies between the new and existing polices": "Remove all dependencies between the new and existing polices",
+  "Remove interface": "Remove interface",
+  "Remove label selector": "Remove label selector",
   "Save": "Save",
   "Scheduling will not be possible at this state": "Scheduling will not be possible at this state",
   "selector key": "selector key",

--- a/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -1,4 +1,5 @@
 import React, { FC, MouseEventHandler } from 'react';
+import produce from 'immer';
 import { NodeNetworkConfigurationEnactmentModelGroupVersionKind } from 'src/console-models';
 import NodeModel, { NodeModelGroupVersionKind } from 'src/console-models/NodeModel';
 import { ENACTMENT_LABEL_NODE } from 'src/utils/constants';
@@ -83,7 +84,14 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({ policy, isOpen, onClose
       acc[selector.key] = selector.value;
       return acc;
     }, {});
-    return onSubmit({ ...policy, spec: { ...policy.spec, nodeSelector } });
+
+    const newPolicy = produce(policy, (draftPolicy) => {
+      selectorLabels.length === 0
+        ? delete draftPolicy.spec.nodeSelector
+        : (draftPolicy.spec.nodeSelector = nodeSelector);
+    });
+
+    return onSubmit(newPolicy);
   };
 
   const nodeAlreadyCovered = qualifiedNodes.find((node) =>

--- a/src/utils/components/NodeSelectorModal/components/LabelRow.tsx
+++ b/src/utils/components/NodeSelectorModal/components/LabelRow.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
-import { Button, FormGroup, GridItem, TextInput } from '@patternfly/react-core';
+import { Button, FormGroup, GridItem, TextInput, Tooltip } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 import { IDLabel } from '../utils/types';
@@ -46,9 +46,11 @@ const LabelRow: FC<LabelRowProps> = ({ label, onChange, onDelete }) => {
 
       <GridItem span={1}>
         <FormGroup label=" " fieldId={`label-${id}-delete-btn`}>
-          <Button variant="plain" onClick={() => onDelete(id)}>
-            <MinusCircleIcon />
-          </Button>
+          <Tooltip content={t('Remove label selector')}>
+            <Button variant="plain" onClick={() => onDelete(id)}>
+              <MinusCircleIcon />
+            </Button>
+          </Tooltip>
         </FormGroup>
       </GridItem>
     </>

--- a/src/utils/components/PolicyForm/PolicyInterface.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterface.tsx
@@ -290,7 +290,10 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               <Checkbox
                 label={t('Auto-DNS')}
                 id={`policy-interface-dns-${id}`}
-                isChecked={policyInterface?.ipv4[AUTO_DNS]}
+                isChecked={
+                  policyInterface?.ipv4[AUTO_DNS] === true ||
+                  policyInterface?.ipv4[AUTO_DNS] === undefined
+                }
                 onChange={(checked) =>
                   onInterfaceChange((draftInterface) => (draftInterface.ipv4[AUTO_DNS] = checked))
                 }
@@ -298,7 +301,10 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               <Checkbox
                 label={t('Auto-routes')}
                 id={`policy-interface-routes-${id}`}
-                isChecked={policyInterface?.ipv4[AUTO_ROUTES]}
+                isChecked={
+                  policyInterface?.ipv4[AUTO_ROUTES] === true ||
+                  policyInterface?.ipv4[AUTO_ROUTES] === undefined
+                }
                 onChange={(checked) =>
                   onInterfaceChange(
                     (draftInterface) => (draftInterface.ipv4[AUTO_ROUTES] = checked),
@@ -308,7 +314,10 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               <Checkbox
                 label={t('Auto-gateway')}
                 id={`policy-interface-gateway-${id}`}
-                isChecked={policyInterface?.ipv4[AUTO_GATEWAY]}
+                isChecked={
+                  policyInterface?.ipv4[AUTO_GATEWAY] === true ||
+                  policyInterface?.ipv4[AUTO_GATEWAY] === undefined
+                }
                 onChange={(checked) =>
                   onInterfaceChange(
                     (draftInterface) => (draftInterface.ipv4[AUTO_GATEWAY] = checked),

--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -1,7 +1,12 @@
 import React, { FC, useRef, useState } from 'react';
 import { Updater } from 'use-immer';
 
-import { Button, FormFieldGroupExpandable, FormFieldGroupHeader } from '@patternfly/react-core';
+import {
+  Button,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  Tooltip,
+} from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import { NodeNetworkConfigurationInterface, V1NodeNetworkConfigurationPolicy } from '@types';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
@@ -60,13 +65,15 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
                 id: `nncp-interface-${index}`,
               }}
               actions={
-                <Button
-                  variant="plain"
-                  aria-label={t('Remove')}
-                  onClick={() => removeInterface(index)}
-                >
-                  <MinusCircleIcon />
-                </Button>
+                <Tooltip content={t('Remove interface')}>
+                  <Button
+                    variant="plain"
+                    aria-label={t('Remove')}
+                    onClick={() => removeInterface(index)}
+                  >
+                    <MinusCircleIcon />
+                  </Button>
+                </Tooltip>
               }
             />
           }


### PR DESCRIPTION
Main fix: auto-DNS, auto-routes, and auto-gateway by default are `true` when not specified. So make them `true` by default also in the UI.

Small fixes: 
- add tooltips
- remove `nodeselector` field in the specs if no labels are provided

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/a4bb9101-bc05-468e-9064-ac9df07f380c)
