### PR TITLE
OCPBUGS-15878: fix radio buttons on policy form

### DIFF
--- a/src/utils/components/PolicyForm/PolicyInterface.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterface.tsx
@@ -234,8 +234,8 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               <FlexItem>
                 <Radio
                   label={t('IP address')}
-                  name="ip-or-dhcp"
-                  id="ip"
+                  name={`ip-or-dhcp-${id}`}
+                  id={`ip-${id}`}
                   isChecked={!policyInterface?.ipv4?.dhcp}
                   onChange={() => onAddressChange('')}
                 />
@@ -244,8 +244,8 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
               <FlexItem>
                 <Radio
                   label={t('DHCP')}
-                  name="ip-or-dhcp"
-                  id="dhcp"
+                  name={`ip-or-dhcp-${id}`}
+                  id={`dhcp-${id}`}
                   isChecked={policyInterface?.ipv4?.dhcp}
                   onChange={onDHCPChange}
                 />

--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -54,7 +54,7 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
     <>
       {policy?.spec?.desiredState?.interfaces.map((policyInterface, index) => (
         <FormFieldGroupExpandable
-          key={`${policyInterface.type}-${index}`}
+          key={`${policyInterface.type}-${policyInterface?.name}`}
           className="policy-interface__expandable"
           toggleAriaLabel={t('Details')}
           isExpanded={true}


### PR DESCRIPTION
Just fix ids. Patternfly seems to use them to select and deselect elements in the whole form