### PR TITLE
Filter also interfaces with rowFilter

### DIFF
--- a/src/utils/components/PolicyForm/BondOptions.tsx
+++ b/src/utils/components/PolicyForm/BondOptions.tsx
@@ -50,7 +50,6 @@ const BondOptions: FC<BondOptionsProps> = ({ id, onInterfaceChange, policyInterf
   const onOptionAdd = () => {
     onInterfaceChange((draftInterface) => {
       ensurePath(draftInterface, 'link-aggregation.options');
-      console.log(selectableOptions[0]);
       draftInterface['link-aggregation'].options[selectableOptions[0]] = '';
     });
   };

--- a/src/utils/hooks/useQueryParams.ts
+++ b/src/utils/hooks/useQueryParams.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router';
+
+const useQueryParams = () => {
+  const { search } = useLocation();
+  return useMemo(() => Object.fromEntries(new URLSearchParams(search)), [search]);
+};
+
+export default useQueryParams;

--- a/src/views/states/list/StatesList.tsx
+++ b/src/views/states/list/StatesList.tsx
@@ -23,6 +23,7 @@ import InterfaceDrawer from './components/InterfaceDrawer/InterfaceDrawer';
 import StateRow from './components/StateRow';
 import StatusBox from './components/StatusBox';
 import useDrawerInterface from './hooks/useDrawerInterface';
+import useSelectedFilters from './hooks/useSelectedFilters';
 import useStateColumns from './hooks/useStateColumns';
 import useStateFilters from './hooks/useStateFilters';
 
@@ -44,6 +45,7 @@ const StatesList: FC = () => {
   const { onPaginationChange, pagination } = usePagination();
   const [columns, activeColumns] = useStateColumns();
   const filters = useStateFilters();
+  const selectedFilters = useSelectedFilters();
   const [data, filteredData, onFilterChange] = useListPageFilter(states, filters);
 
   const paginatedData = filteredData.slice(pagination?.startIndex, pagination?.endIndex + 1);
@@ -106,7 +108,7 @@ const StatesList: FC = () => {
                 key={nns?.metadata?.name}
                 obj={nns}
                 activeColumnIDs={new Set(activeColumns.map(({ id }) => id))}
-                rowData={{ rowIndex: index }}
+                rowData={{ rowIndex: index, selectedFilters }}
               />
             ))}
           </Table>

--- a/src/views/states/list/components/InterfacesTable.tsx
+++ b/src/views/states/list/components/InterfacesTable.tsx
@@ -26,14 +26,16 @@ const InterfacesTable: FC<InterfacesTableProps> = ({ interfacesByType, nodeNetwo
     >
       <TableHeader />
       <Tbody>
-        {Object.keys(interfacesByType).map((interfaceType) => (
-          <InterfacesTypeSection
-            key={interfaceType}
-            interfaceType={interfaceType}
-            interfaces={interfacesByType[interfaceType]}
-            nodeNetworkState={nodeNetworkState}
-          />
-        ))}
+        {Object.keys(interfacesByType)
+          .sort()
+          .map((interfaceType) => (
+            <InterfacesTypeSection
+              key={interfaceType}
+              interfaceType={interfaceType}
+              interfaces={interfacesByType[interfaceType]}
+              nodeNetworkState={nodeNetworkState}
+            />
+          ))}
       </Tbody>
     </Table>
   );

--- a/src/views/states/list/components/utils.ts
+++ b/src/views/states/list/components/utils.ts
@@ -1,0 +1,46 @@
+import { InterfaceType, NodeNetworkConfigurationInterface } from '@types';
+
+import { FILTERS_TYPES } from '../constants';
+
+export const interfaceFilters = {
+  [FILTERS_TYPES.INTERFACE_STATE]: (selectedInput, obj) => {
+    if (!selectedInput.length) return true;
+    return selectedInput.some((status) => obj.state.toLowerCase() === status);
+  },
+  [FILTERS_TYPES.INTERFACE_TYPE]: (selectedInput, obj) => {
+    if (!selectedInput.length) return true;
+    return selectedInput.some((interfaceType) => obj.type === interfaceType);
+  },
+  [FILTERS_TYPES.IP_FILTER]: (selectedInput, obj) => {
+    if (!selectedInput.length) return true;
+    return selectedInput.some((ipType) => !!obj[ipType]);
+  },
+} as const;
+
+export const filterInterfaces = (
+  interfaces: NodeNetworkConfigurationInterface[],
+  selectedFilters,
+) => {
+  if (!Object.keys(selectedFilters).length) return interfaces;
+
+  return interfaces.filter((iface) =>
+    Object.keys(selectedFilters).every((filterType) => {
+      const selectedValues = selectedFilters[filterType];
+      const filter = interfaceFilters[filterType];
+
+      if (!filter) return true;
+
+      return filter(selectedValues, iface);
+    }),
+  );
+};
+
+export const getInterfacesByType = (filteredInterfaces: NodeNetworkConfigurationInterface[]) =>
+  filteredInterfaces?.reduce((acc, iface) => {
+    // Skip loopback interfaces from the list
+    if (iface.type === InterfaceType.LOOPBACK) return acc;
+
+    acc[iface.type] ??= [];
+    acc[iface.type].push(iface);
+    return acc;
+  }, {} as { [key: string]: NodeNetworkConfigurationInterface[] });

--- a/src/views/states/list/constants.ts
+++ b/src/views/states/list/constants.ts
@@ -3,3 +3,9 @@ import NodeNetworkStateModel from 'src/console-models/NodeNetworkStateModel';
 import { getResourceUrl } from '@utils/helpers';
 
 export const baseListUrl = getResourceUrl({ model: NodeNetworkStateModel });
+
+export const FILTERS_TYPES = {
+  INTERFACE_STATE: 'interface-state',
+  INTERFACE_TYPE: 'interface-type',
+  IP_FILTER: 'ip-filter',
+} as const;

--- a/src/views/states/list/hooks/useSelectedFilters.ts
+++ b/src/views/states/list/hooks/useSelectedFilters.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+import useQueryParams from '@utils/hooks/useQueryParams';
+
+import { FILTERS_TYPES } from '../constants';
+
+export type SelectedFilters = {
+  [filter in typeof FILTERS_TYPES as string]: string[];
+};
+
+const useSelectedFilters = (): SelectedFilters => {
+  const queryParams = useQueryParams();
+
+  return useMemo(
+    () =>
+      Object.keys(queryParams)
+        .filter((queryKey) => queryKey.startsWith('rowFilter-'))
+        .reduce((acc, queryKey) => {
+          const filterType = queryKey.replace('rowFilter-', '');
+          const filterValue = queryParams[queryKey].split(',');
+          acc[filterType] = filterValue;
+          return acc;
+        }, {} as SelectedFilters),
+    [queryParams],
+  );
+};
+
+export default useSelectedFilters;

--- a/src/views/states/list/hooks/useStateFilters.ts
+++ b/src/views/states/list/hooks/useStateFilters.ts
@@ -3,13 +3,15 @@ import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { InterfaceType, NodeNetworkConfigurationInterface, V1beta1NodeNetworkState } from '@types';
 
+import { FILTERS_TYPES } from '../constants';
+
 const useStateFilters = (): RowFilter<V1beta1NodeNetworkState>[] => {
   const { t } = useNMStateTranslation();
 
   return [
     {
       filterGroupName: t('Interface state'),
-      type: 'interface-state',
+      type: FILTERS_TYPES.INTERFACE_STATE,
       filter: (selectedIpTypes, obj) => {
         if (!selectedIpTypes.selected.length) return true;
         return selectedIpTypes.selected.some((status) =>
@@ -33,7 +35,7 @@ const useStateFilters = (): RowFilter<V1beta1NodeNetworkState>[] => {
     },
     {
       filterGroupName: t('Interface type'),
-      type: 'interface-type',
+      type: FILTERS_TYPES.INTERFACE_TYPE,
       filter: (selectedInterfaceTypes, obj) => {
         if (!selectedInterfaceTypes.selected.length) return true;
         return selectedInterfaceTypes.selected.some((interfaceType) =>
@@ -58,7 +60,7 @@ const useStateFilters = (): RowFilter<V1beta1NodeNetworkState>[] => {
     },
     {
       filterGroupName: t('IP'),
-      type: 'ip-filter',
+      type: FILTERS_TYPES.IP_FILTER,
       filter: (selectedIpTypes, obj) => {
         if (!selectedIpTypes.selected.length) return true;
         return selectedIpTypes.selected.some((ipType) =>


### PR DESCRIPTION
With row filters don't just filter NNS, but also interfaces

- sort nns interface types


**Before**
![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/3125fb1e-f869-45de-8b04-23c7dd15c1ea)


**After**
![Screenshot from 2023-07-19 11-55-04](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/ee30111d-73f9-4f34-b739-b38c8e0350ee)


Sorted:

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/431401d8-e601-4696-8a7d-bcf2adf27e24)
