### PR TITLE
OCPBUGS-16598: Do not use name as key

### DIFF
--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -54,7 +54,7 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
     <>
       {policy?.spec?.desiredState?.interfaces.map((policyInterface, index) => (
         <FormFieldGroupExpandable
-          key={`${policyInterface.type}-${policyInterface?.name}`}
+          key={`${policyInterface.type}-${index}`}
           className="policy-interface__expandable"
           toggleAriaLabel={t('Details')}
           isExpanded={true}


### PR DESCRIPTION
Using the interface name as part of key, make react loose focus on the input element