### PR TITLE
Remove copy-mac-from attribute if input cleaned up

### DIFF
--- a/src/utils/components/PolicyForm/CopyMAC.tsx
+++ b/src/utils/components/PolicyForm/CopyMAC.tsx
@@ -17,7 +17,7 @@ const CopyMAC: FC<CopyMACProps> = ({ id, policyInterface, onInterfaceChange }) =
 
   const onPortChange = (value) => {
     onInterfaceChange((draftInterface) => {
-      draftInterface['copy-mac-from'] = value;
+      value ? (draftInterface['copy-mac-from'] = value) : delete draftInterface['copy-mac-from'];
     });
   };
 


### PR DESCRIPTION
If the user clean up the copy-mac-from field, we have to remove the key. 
An empty property result in a wrong structured policy