### PR TITLE
OCPBUGS-16642: disable remove button for created interfaces

### DIFF
--- a/src/utils/components/PolicyForm/PolicyInterface.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterface.tsx
@@ -38,7 +38,7 @@ type HandleSelectChange = SelectProps['onSelect'];
 
 type PolicyInterfaceProps = {
   id: number;
-  createdInterface?: boolean;
+  isInterfaceCreated?: boolean;
   policyInterface?: NodeNetworkConfigurationInterface;
   onInterfaceChange?: (updateInterface: onInterfaceChangeType) => void;
 };
@@ -47,7 +47,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
   id,
   policyInterface,
   onInterfaceChange,
-  createdInterface = true,
+  isInterfaceCreated = true,
 }) => {
   const { t } = useNMStateTranslation();
   const [isStateOpen, setStateOpen] = useState(false);
@@ -178,7 +178,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
           name={`policy-interface-name-${id}`}
           value={policyInterface?.name}
           onChange={handleNameChange}
-          isDisabled={createdInterface}
+          isDisabled={isInterfaceCreated}
         />
       </FormGroup>
       <FormGroup
@@ -212,7 +212,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
           onSelect={handleTypechange}
           variant={SelectVariant.single}
           selections={policyInterface?.type}
-          isDisabled={createdInterface}
+          isDisabled={isInterfaceCreated}
         >
           {Object.entries(INTERFACE_TYPE_OPTIONS).map(([key, value]) => (
             <SelectOption key={key} value={key}>
@@ -354,7 +354,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
             label={
               <Text>
                 {t('Enable STP')}{' '}
-                {createdInterface && (
+                {isInterfaceCreated && (
                   <Popover
                     aria-label={'Help'}
                     bodyContent={() => <div>{t('Edit the STP in the YAML file')}</div>}
@@ -367,7 +367,7 @@ const PolicyInterface: FC<PolicyInterfaceProps> = ({
             id={`policy-interface-stp-${id}`}
             isChecked={policyInterface?.bridge?.options?.stp?.enabled}
             onChange={onSTPChange}
-            isDisabled={createdInterface}
+            isDisabled={isInterfaceCreated}
           />
         </FormGroup>
       )}

--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -28,14 +28,14 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
 }) => {
   const createdPolicy = useRef(createForm ? undefined : policy);
 
+  const createdInterfacesNames = createdPolicy?.current?.spec?.desiredState?.interfaces?.map(
+    (inFace) => inFace?.name,
+  );
+
   const [interfaceToDelete, setInterfaceToDelete] = useState<NodeNetworkConfigurationInterface>();
   const { t } = useNMStateTranslation();
 
   const removeInterface = (interfaceIndex: number) => {
-    const createdInterfacesNames = createdPolicy?.current?.spec?.desiredState?.interfaces?.map(
-      (inFace) => inFace?.name,
-    );
-
     if (
       createdInterfacesNames?.includes(policy?.spec?.desiredState?.interfaces[interfaceIndex]?.name)
     ) {
@@ -52,48 +52,50 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
 
   return (
     <>
-      {policy?.spec?.desiredState?.interfaces.map((policyInterface, index) => (
-        <FormFieldGroupExpandable
-          key={`${policyInterface.type}-${index}`}
-          className="policy-interface__expandable"
-          toggleAriaLabel={t('Details')}
-          isExpanded={true}
-          header={
-            <FormFieldGroupHeader
-              titleText={{
-                text: getExpandableTitle(policyInterface, t),
-                id: `nncp-interface-${index}`,
-              }}
-              actions={
-                <Tooltip content={t('Remove interface')}>
-                  <Button
-                    variant="plain"
-                    aria-label={t('Remove')}
-                    onClick={() => removeInterface(index)}
-                  >
-                    <MinusCircleIcon />
-                  </Button>
-                </Tooltip>
+      {policy?.spec?.desiredState?.interfaces.map((policyInterface, index) => {
+        const interfaceCreated = createdInterfacesNames?.includes(policyInterface?.name);
+        return (
+          <FormFieldGroupExpandable
+            key={`${policyInterface.type}-${index}`}
+            className="policy-interface__expandable"
+            toggleAriaLabel={t('Details')}
+            isExpanded={true}
+            header={
+              <FormFieldGroupHeader
+                titleText={{
+                  text: getExpandableTitle(policyInterface, t),
+                  id: `nncp-interface-${index}`,
+                }}
+                actions={
+                  <Tooltip content={t('Remove interface')}>
+                    <span>
+                      <Button
+                        variant="plain"
+                        aria-label={t('Remove')}
+                        isDisabled={Boolean(interfaceCreated)}
+                        onClick={() => removeInterface(index)}
+                      >
+                        <MinusCircleIcon />
+                      </Button>
+                    </span>
+                  </Tooltip>
+                }
+              />
+            }
+          >
+            <PolicyInterface
+              id={index}
+              isInterfaceCreated={Boolean(interfaceCreated)}
+              policyInterface={policyInterface}
+              onInterfaceChange={(updateInterface: onInterfaceChangeType) =>
+                setPolicy((draftPolicy) => {
+                  updateInterface(draftPolicy.spec.desiredState.interfaces[index]);
+                })
               }
             />
-          }
-        >
-          <PolicyInterface
-            id={index}
-            createdInterface={
-              !!createdPolicy?.current?.spec?.desiredState?.interfaces?.find(
-                (iface) => iface.name === policyInterface.name,
-              )
-            }
-            policyInterface={policyInterface}
-            onInterfaceChange={(updateInterface: onInterfaceChangeType) =>
-              setPolicy((draftPolicy) => {
-                updateInterface(draftPolicy.spec.desiredState.interfaces[index]);
-              })
-            }
-          />
-        </FormFieldGroupExpandable>
-      ))}
+          </FormFieldGroupExpandable>
+        );
+      })}
       {interfaceToDelete && (
         <DeleteInterfaceModal
           policyInterface={interfaceToDelete}


### PR DESCRIPTION
On policy editing, do not allow to remove already created interfaces 



![Screenshot from 2023-07-26 14-58-36](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/a70248e5-4f73-459a-8fa3-945e21edea62)



![Screenshot from 2023-07-26 14-58-42](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/79322368-c79a-485a-9218-09ef6ee7c39d)

