### PR TITLE
CNV-31832: add linux-bridge as filter

### DIFF
--- a/cypress/e2e/StatusList.spec.cy.ts
+++ b/cypress/e2e/StatusList.spec.cy.ts
@@ -10,6 +10,18 @@ describe('NodeNetworkState list', () => {
     cy.login();
   });
 
+  it('Empty state', () => {
+    cy.intercept('GET', '/api/kubernetes/apis/nmstate.io/v1beta1/nodenetworkstates*', {
+      fixture: 'NodeNetworkStatusEmpty.json',
+    }).as('getStatuses');
+
+    cy.visit('/k8s/cluster/nmstate.io~v1beta1~NodeNetworkState');
+
+    cy.wait(['@getStatuses'], { timeout: 40000 });
+
+    cy.get('.pf-c-empty-state').should('contain', 'No NodeNetworkStates found');
+  });
+
   it('with one VID instace ', () => {
     cy.intercept('GET', '/api/kubernetes/apis/nmstate.io/v1beta1/nodenetworkstates*', {
       fixture: 'NodeNetworkStatusWithVID.json',

--- a/cypress/fixtures/NodeNetworkStatusEmpty.json
+++ b/cypress/fixtures/NodeNetworkStatusEmpty.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "nmstate.io/v1beta1",
+  "items": [],
+  "kind": "NodeNetworkStateList",
+  "metadata": {
+    "continue": "",
+    "resourceVersion": "28666056"
+  }
+}

--- a/src/views/states/list/StatesList.tsx
+++ b/src/views/states/list/StatesList.tsx
@@ -20,6 +20,7 @@ import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
 
 import InterfaceDrawer from './components/InterfaceDrawer/InterfaceDrawer';
+import NNStateEmptyState from './components/NNStateEmptyState';
 import StateRow from './components/StateRow';
 import StatusBox from './components/StatusBox';
 import useDrawerInterface from './hooks/useDrawerInterface';
@@ -55,7 +56,7 @@ const StatesList: FC = () => {
     <>
       <ListPageHeader title={t(NodeNetworkStateModel.label)}></ListPageHeader>
       <ListPageBody>
-        <StatusBox loaded={statesLoaded} error={statesError} data={states}>
+        <StatusBox loaded={statesLoaded} error={statesError}>
           <div className="list-managment-group">
             <ListPageFilter
               data={data}
@@ -101,22 +102,26 @@ const StatesList: FC = () => {
             />
           </div>
 
-          <Table
-            cells={activeColumns}
-            rows={paginatedData}
-            gridBreakPoint={TableGridBreakpoint.none}
-            role="presentation"
-          >
-            <TableHeader />
-            {paginatedData.map((nns, index) => (
-              <StateRow
-                key={nns?.metadata?.name}
-                obj={nns}
-                activeColumnIDs={new Set(activeColumns.map(({ id }) => id))}
-                rowData={{ rowIndex: index, selectedFilters }}
-              />
-            ))}
-          </Table>
+          {filteredData.length > 0 ? (
+            <Table
+              cells={activeColumns}
+              rows={paginatedData}
+              gridBreakPoint={TableGridBreakpoint.none}
+              role="presentation"
+            >
+              <TableHeader />
+              {paginatedData.map((nnstate, index) => (
+                <StateRow
+                  key={nnstate?.metadata?.name}
+                  obj={nnstate}
+                  activeColumnIDs={new Set(activeColumns.map(({ id }) => id))}
+                  rowData={{ rowIndex: index, selectedFilters }}
+                />
+              ))}
+            </Table>
+          ) : (
+            <NNStateEmptyState />
+          )}
         </StatusBox>
       </ListPageBody>
       <InterfaceDrawer selectedInterface={selectedInterface} />

--- a/src/views/states/list/components/NNStateEmptyState.tsx
+++ b/src/views/states/list/components/NNStateEmptyState.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react';
+
+import { EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
+import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+
+const NNStateEmptyState: FC = () => {
+  const { t } = useNMStateTranslation();
+  return (
+    <EmptyState variant={EmptyStateVariant.full}>
+      <Title headingLevel="h5" size="lg">
+        {t('No NodeNetworkStates found')}
+      </Title>
+    </EmptyState>
+  );
+};
+
+export default NNStateEmptyState;

--- a/src/views/states/list/components/StatusBox.tsx
+++ b/src/views/states/list/components/StatusBox.tsx
@@ -2,7 +2,6 @@ import React, { FC, PropsWithChildren } from 'react';
 import { Trans } from 'react-i18next';
 
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { V1beta1NodeNetworkState } from '@types';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
 
 import ListSkeleton from './ListSkeleton';
@@ -11,10 +10,9 @@ type StatusBoxProps = PropsWithChildren<{
   loaded: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
-  data: V1beta1NodeNetworkState[];
 }>;
 
-const StatusBox: FC<StatusBoxProps> = ({ loaded, error, data, children }) => {
+const StatusBox: FC<StatusBoxProps> = ({ loaded, error, children }) => {
   const { t } = useNMStateTranslation();
 
   if (error)
@@ -36,15 +34,6 @@ const StatusBox: FC<StatusBoxProps> = ({ loaded, error, data, children }) => {
   if (!loaded) {
     return <ListSkeleton />;
   }
-
-  if (!data.length)
-    return (
-      <div className="cos-status-box">
-        <div data-test="empty-message" className="pf-u-text-align-center">
-          {t('No NodeNetworkStates found')}
-        </div>
-      </div>
-    );
 
   return <>{children}</>;
 };

--- a/src/views/states/list/hooks/useStateFilters.ts
+++ b/src/views/states/list/hooks/useStateFilters.ts
@@ -73,6 +73,7 @@ const useStateFilters = (): RowFilter<V1beta1NodeNetworkState>[] => {
         InterfaceType.OVS_INTERFACE,
         InterfaceType.BOND,
         InterfaceType.ETHERNET,
+        InterfaceType.LINUX_BRIDGE,
       ].map((interfaceType) => ({
         id: interfaceType,
         title: interfaceType,


### PR DESCRIPTION
- Add linux-bridge as a filter for the interface types
- Fix the empty state


Previously the `No NodeNetworkStates found` was showing up only with no states in the cluster.
Now the message is displayed even when there are no states with the filters selected ( as in all other pages)



**Before**
![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/dd1b4c8e-9955-4a3f-a5d4-59f41c14a434)



**After**

![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/3ef7d48b-92fa-47e5-a6bd-4b3b13f5d0a5)


![Screenshot from 2023-08-11 16-26-54](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/1b327d44-2ddb-44bd-8c46-3e9f19100543)
