### PR TITLE
Change tooltip on remove interface if interface created

### DIFF
--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -28,6 +28,7 @@
   "Create": "Create",
   "Create NodeNetworkConfigurationPolicy": "Create NodeNetworkConfigurationPolicy",
   "Create NodeNetworkConfigurationPolicy error": "Create NodeNetworkConfigurationPolicy error",
+  "Created interfaces cannot be removed": "Created interfaces cannot be removed",
   "Delete": "Delete",
   "Delete NodeNetworkConfigurationPolicy?": "Delete NodeNetworkConfigurationPolicy?",
   "Delete NodeNetworkConfigurationPolicyInterface?": "Delete NodeNetworkConfigurationPolicyInterface?",

--- a/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
+++ b/src/utils/components/PolicyForm/PolicyInterfaceExpandable.tsx
@@ -67,7 +67,13 @@ const PolicyInterfacesExpandable: FC<PolicyInterfacesExpandableProps> = ({
                   id: `nncp-interface-${index}`,
                 }}
                 actions={
-                  <Tooltip content={t('Remove interface')}>
+                  <Tooltip
+                    content={
+                      interfaceCreated
+                        ? t('Created interfaces cannot be removed')
+                        : t('Remove interface')
+                    }
+                  >
                     <span>
                       <Button
                         variant="plain"


### PR DESCRIPTION
Created interfaces cannot be edited so we have disabled the remove button.

Here we change the tooltip to communicate why it's disabled 

**Before**
![Screenshot from 2023-08-22 11-34-50](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/c1b8c2f5-08d3-4e30-92b2-22154c6171ff)


**After**
![Screenshot from 2023-08-22 11-34-04](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/2583c631-5727-4db3-8fad-d096a08e51e7)

