### PR TITLE
Set initial interface state in nncp form

### DIFF
--- a/src/utils/components/PolicyForm/PolicyForm.tsx
+++ b/src/utils/components/PolicyForm/PolicyForm.tsx
@@ -48,6 +48,7 @@ const PolicyForm: FC<PolicyFormProps> = ({ policy, setPolicy, createForm = false
       draftPolicy.spec.desiredState.interfaces.unshift({
         type: InterfaceType.LINUX_BRIDGE,
         name: `interface-${draftPolicy.spec.desiredState.interfaces.length}`,
+        state: 'up',
       });
     });
   };


### PR DESCRIPTION
Creating a new interface in the interface form would generate an interface without state.

```yaml
spec:
  desiredState:
    interfaces:
      - name: brm2       // second created  interface 
        type: linux-bridge
      - name: brm1     // first created  interface 
        type: linux-bridge
      - name: brm0       // initial interface 
        state: up
        type: linux-bridge
```
It works because probably the default state is 'up' but its not documented so lets just add it explicitly. This behavior can change over time. 