### PR TITLE
OCPBUGS-17245: use getPorts also in Popover interface

### DIFF
--- a/src/views/states/list/components/InterfacesPopoverBody.tsx
+++ b/src/views/states/list/components/InterfacesPopoverBody.tsx
@@ -8,10 +8,12 @@ import {
   FlexItem,
   List,
   ListItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
 import { NodeNetworkConfigurationInterface, V1beta1NodeNetworkState } from '@types';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+import { getPorts } from '@utils/interfaces/getters';
 
 import useDrawerInterface from '../hooks/useDrawerInterface';
 
@@ -47,6 +49,7 @@ const InterfacesPopoverBody: FC<InterfacesPopoverBodyProps> = ({
     <List isPlain className="interfaces-popover-body" isBordered>
       {interfaces.map((iface) => {
         const address = iface.ipv4?.address || iface.ipv6?.address;
+        const ports = getPorts(iface);
         const Icon = iface.state.toLowerCase() === 'up' ? LongArrowAltUpIcon : LongArrowAltDownIcon;
 
         return (
@@ -83,7 +86,23 @@ const InterfacesPopoverBody: FC<InterfacesPopoverBodyProps> = ({
               <FirstColumn>
                 <strong>{t('Ports')}</strong>
               </FirstColumn>
-              <SecondColumn>{iface.bridge?.port?.length || '-'}</SecondColumn>
+              <SecondColumn>
+                {ports?.length ? (
+                  <Tooltip
+                    content={
+                      <List isPlain>
+                        {ports.map((port) => (
+                          <ListItem key={port}>{port}</ListItem>
+                        ))}
+                      </List>
+                    }
+                  >
+                    <span>{ports.length}</span>
+                  </Tooltip>
+                ) : (
+                  '-'
+                )}
+              </SecondColumn>
             </Row>
             <Row>
               <FirstColumn>


### PR DESCRIPTION
Can't create screenshots with bonds interface, but just use the same method that works for the interface table also in the popover and the bug is fixed . 


`getPorts` return the ports from bridge and also bonds interface. 
In the popover i was just using the bridge ports

![Screenshot from 2023-08-25 14-47-05](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/7cb614e0-8305-451a-96c1-c5b38f5a3b9f)
![Screenshot from 2023-08-25 14-47-09](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/929f805f-2489-478b-a2d3-da24d72d0343)
