### PR TITLE
CNV-32391: Use Policy abbr as resource icon

### DIFF
--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -41,7 +41,6 @@
   "Display all {{status}} enactments": "Display all {{status}} enactments",
   "Down": "Down",
   "Download YAML": "Download YAML",
-  "DS": "DS",
   "Edit": "Edit",
   "Edit NodeNetworkConfigurationPolicy": "Edit NodeNetworkConfigurationPolicy",
   "Edit the STP in the YAML file": "Edit the STP in the YAML file",

--- a/src/views/policies/details/PolicyPageTitle.tsx
+++ b/src/views/policies/details/PolicyPageTitle.tsx
@@ -44,7 +44,9 @@ const PolicyPageTitle: FC<PolicyPageTitleProps> = ({ policy, name }) => {
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
         <span className="co-m-pane__heading">
           <h1 className="co-m-pane__name co-resource-item">
-            <span className="co-m-resource-icon co-m-resource-icon--lg">{t('DS')}</span>
+            <span className="co-m-resource-icon co-m-resource-icon--lg">
+              {NodeNetworkConfigurationPolicyModel.abbr}
+            </span>
             <span data-test-id="resource-title" className="co-resource-item__resource-name">
               {name ?? policy?.metadata?.name}{' '}
             </span>


### PR DESCRIPTION
I was using a fixed string 'DS' (even translated). Don't know why...