### PR TITLE
OCPBUGS-18330: cancel button in the create policy form

### DIFF
--- a/src/views/policies/new/NewPolicy.tsx
+++ b/src/views/policies/new/NewPolicy.tsx
@@ -111,6 +111,10 @@ const NewPolicy: FC = () => {
         >
           {t('Create')}
         </Button>
+
+        <Button onClick={history.goBack} variant={ButtonVariant.secondary}>
+          {t('Cancel')}
+        </Button>
       </ActionGroup>
     </PageSection>
   );


### PR DESCRIPTION
There was no cancel button before 


![image](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/dbe9813b-a280-4cb7-9003-b1332b67d24b)
