### PR TITLE
CNV-36299: Sort by name NNS

### DIFF
--- a/src/views/states/list/hooks/useSortStates.ts
+++ b/src/views/states/list/hooks/useSortStates.ts
@@ -1,0 +1,41 @@
+import { MouseEvent, useState } from 'react';
+
+import { SortByDirection } from '@patternfly/react-table';
+import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base';
+import { V1beta1NodeNetworkState } from '@types';
+
+const useSortStates = (
+  nodeNetworkStates: V1beta1NodeNetworkState[],
+): { sortedStates: V1beta1NodeNetworkState[]; nameSortParams: ThSortType } => {
+  const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
+  const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | null>(null);
+
+  let sortedStates = nodeNetworkStates;
+  if (activeSortIndex === 1) {
+    sortedStates = nodeNetworkStates.sort((a, b) => {
+      const aValue = a.metadata.name as string;
+      const bValue = b.metadata.name as string;
+
+      if (activeSortDirection === 'asc') {
+        return (aValue as string).localeCompare(bValue);
+      }
+      return (bValue as string).localeCompare(aValue);
+    });
+  }
+
+  const nameSortParams: ThSortType = {
+    sortBy: {
+      index: activeSortIndex,
+      direction: activeSortDirection,
+    },
+    onSort: (_event: MouseEvent, index: number, direction: SortByDirection) => {
+      setActiveSortIndex(index);
+      setActiveSortDirection(direction);
+    },
+    columnIndex: 1,
+  };
+
+  return { sortedStates, nameSortParams };
+};
+
+export default useSortStates;

--- a/src/views/states/list/hooks/useStateColumns.ts
+++ b/src/views/states/list/hooks/useStateColumns.ts
@@ -7,6 +7,8 @@ import {
   useActiveColumns,
 } from '@openshift-console/dynamic-plugin-sdk';
 
+export const COLUMN_NAME_ID = 'name';
+
 const useStateColumns = (): [
   TableColumn<K8sResourceCommon>[],
   TableColumn<K8sResourceCommon>[],
@@ -21,7 +23,7 @@ const useStateColumns = (): [
     },
     {
       title: t('Name'),
-      id: 'name',
+      id: COLUMN_NAME_ID,
     },
     {
       title: t('Network interface'),

--- a/src/views/states/list/states-list.scss
+++ b/src/views/states/list/states-list.scss
@@ -1,0 +1,7 @@
+.nns-list-management-group {
+  display: flex;
+  justify-content: space-between;
+  &__pagination {
+    flex-grow: 1;
+  }
+}


### PR DESCRIPTION
Sort NNS by name on toggle name column sort icon.

The table is not the `VirtualizedTable` as it does not support the automatic sort. So we need to do it manually. 

patternfly: https://v4-archive.patternfly.org/v4/components/table/#composable-sortable--wrapping-headers

![Screenshot from 2023-12-11 11-17-12](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/7d2cfa09-a895-42b9-aa60-fec083fab545)
![Screenshot from 2023-12-11 11-17-08](https://github.com/nmstate/nmstate-console-plugin/assets/29160323/0fa13332-9e7c-4538-9fbf-be0f264ae777)
