### PR TITLE
OCPBUGS-24194: Remove pull policy always

### DIFF
--- a/deployment/nmstate-console-plugin/templates/deployment.tpl
+++ b/deployment/nmstate-console-plugin/templates/deployment.tpl
@@ -25,7 +25,7 @@ spec:
           ports:
             - containerPort: 9443
               protocol: TCP
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Never use Always strategy for `imagePullPolicy`