### PR TITLE
Remove pf-5 references on tests

### DIFF
--- a/cypress/e2e/StatusList.spec.cy.ts
+++ b/cypress/e2e/StatusList.spec.cy.ts
@@ -21,7 +21,7 @@ describe('NodeNetworkState list', () => {
 
     cy.wait(['@getStatuses'], { timeout: 40000 });
 
-    cy.get('.pf-v5-c-empty-state').should('contain', 'No NodeNetworkStates found');
+    cy.get('h5').should('contain', 'No NodeNetworkStates found');
   });
 
   it('with one VID instace ', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -43,7 +43,7 @@ Cypress.Commands.add('login', (provider, username, password) => {
 
     const idp = provider || KUBEADMIN_IDP;
 
-    cy.get('.pf-v5-c-login__main-body').should('be.visible');
+    cy.get('main form').should('be.visible');
 
     cy.get('body').then(($body) => {
       if ($body.text().includes(idp)) {


### PR DESCRIPTION
So that tests would work on all console versions.
Ones with pf5 and pf4