### PR TITLE
OCPBUGS-31855: fix onChange callback patternfly5

### DIFF
--- a/src/utils/components/PolicyForm/BondOptions.tsx
+++ b/src/utils/components/PolicyForm/BondOptions.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, FormEvent } from 'react';
 import { ensurePath } from 'src/utils/helpers';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
@@ -78,7 +78,9 @@ const BondOptions: FC<BondOptionsProps> = ({ id, onInterfaceChange, policyInterf
                 isRequired
                 type="text"
                 value={value}
-                onChange={(newValue) => onOptionValue(key, newValue)}
+                onChange={(event: FormEvent<HTMLInputElement>, newValue: string) =>
+                  onOptionValue(key, newValue)
+                }
                 aria-label={t('selector value')}
               />
             </FormGroup>

--- a/src/utils/components/PolicyForm/CopyMAC.tsx
+++ b/src/utils/components/PolicyForm/CopyMAC.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, FormEvent } from 'react';
 import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 
 import { ExpandableSection, FormGroup, Text, TextInput } from '@patternfly/react-core';
@@ -15,7 +15,7 @@ type CopyMACProps = {
 const CopyMAC: FC<CopyMACProps> = ({ id, policyInterface, onInterfaceChange }) => {
   const { t } = useNMStateTranslation();
 
-  const onPortChange = (value) => {
+  const onPortChange = (event: FormEvent<HTMLInputElement>, value: string) => {
     onInterfaceChange((draftInterface) => {
       value ? (draftInterface['copy-mac-from'] = value) : delete draftInterface['copy-mac-from'];
     });


### PR DESCRIPTION
onChange callback change signature from patternfly 4 to 5. 
It has the event first and after the new value