### PR TITLE
OCPBUGS-42859: Interface with same name causes unexpected behavior in NNS topology

### DIFF
--- a/src/views/states/list/StatesList.tsx
+++ b/src/views/states/list/StatesList.tsx
@@ -18,6 +18,7 @@ import { Button, Flex, Icon, Pagination } from '@patternfly/react-core';
 import { TopologyIcon } from '@patternfly/react-icons';
 import { Table, TableGridBreakpoint, Th, Thead, Tr } from '@patternfly/react-table';
 import { V1beta1NodeNetworkState } from '@types';
+import { isEmpty } from '@utils/helpers';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
 
@@ -77,11 +78,13 @@ const StatesList: FC = () => {
   return (
     <>
       <ListPageHeader title={t(NodeNetworkStateModel.label)}>
-        <Button isInline variant="plain" onClick={() => navigate('/nmstate-topology')}>
-          <Icon>
-            <TopologyIcon />
-          </Icon>
-        </Button>
+        {!isEmpty(states) && (
+          <Button isInline variant="plain" onClick={() => navigate('/nmstate-topology')}>
+            <Icon>
+              <TopologyIcon />
+            </Icon>
+          </Button>
+        )}
       </ListPageHeader>
       <ListPageBody>
         <StatusBox loaded={statesLoaded} error={statesError}>

--- a/src/views/states/topology/components/CustomNode/CustomNode.tsx
+++ b/src/views/states/topology/components/CustomNode/CustomNode.tsx
@@ -18,24 +18,15 @@ type CustomNodeProps = {
   WithDragNodeProps &
   WithDndDropProps;
 
-const CustomNode: FC<CustomNodeProps> = ({ element, onSelect, selected, ...rest }) => {
+const CustomNode: FC<CustomNodeProps> = ({ element, ...rest }) => {
   const data = element.getData();
   const Icon = data.icon;
   const { width, height } = element.getBounds();
 
   const xCenter = (width - ICON_SIZE) / 2;
   const yCenter = (height - ICON_SIZE) / 2;
-
   return (
-    <DefaultNode
-      className="custom-node"
-      badge={data.badge}
-      element={element}
-      onSelect={onSelect}
-      selected={selected}
-      truncateLength={8}
-      {...rest}
-    >
+    <DefaultNode className="custom-node" element={element} truncateLength={8} {...rest}>
       <g transform={`translate(${xCenter}, ${yCenter})`}>
         <Icon width={ICON_SIZE} height={ICON_SIZE} />
       </g>

--- a/src/views/states/topology/utils/position.ts
+++ b/src/views/states/topology/utils/position.ts
@@ -8,16 +8,11 @@ export const saveNodePositions = (visualization: Visualization) => {
 
   // Traverse all nodes and their children
   graph.getNodes().forEach((node) => {
+    nodePositions[node.getId()] = node.getPosition();
     if (node.isGroup()) {
-      // Save the group node position
-      nodePositions[node.getId()] = node.getPosition();
-
-      // Save all child node positions
       node.getAllNodeChildren().forEach((childNode) => {
         nodePositions[childNode.getId()] = childNode.getPosition();
       });
-    } else {
-      nodePositions[node.getId()] = node.getPosition();
     }
   });
 


### PR DESCRIPTION
name property under each interface is not unique, basing the id on the interface name can cause 2 interface with same name to have the same topology node id. this causes to have 2 nodes with same id which renders only one node to the screen which can change with no reason.

Before:
![same-node-b4](https://github.com/user-attachments/assets/e8e1c2fc-df4a-46d2-a3c6-66b432236431)


After:
![same-node-after](https://github.com/user-attachments/assets/1c32a85e-07c6-42b1-8bf9-e86ea4cc49c0)
