### PR TITLE
CNV-49307: fix this for virt perspective

### DIFF
--- a/src/views/policies/manifest.ts
+++ b/src/views/policies/manifest.ts
@@ -54,7 +54,6 @@ export const PolicyExtensions: EncodedExtension[] = [
         '/k8s/cluster/nmstate.io~v1~NodeNetworkConfigurationPolicy/~new/form',
         '/k8s/cluster/nmstate.io~v1~NodeNetworkConfigurationPolicy/~new/yaml',
       ],
-      perspective: 'admin',
       id: 'networking',
       name: '%plugin__nmstate-console-plugin~NodeNetworkConfigurationPolicy%',
       dataAttributes: {


### PR DESCRIPTION


When on virtualization perspective we click on 'Create' the perspective change to admin

removing perspective in the RoutePage definition fix that